### PR TITLE
Add builds folder for monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ config.hotwire.spark.html_paths += %w[ lib ]
 | Name             | Description                                                                                                                  |
 |------------------|------------------------------------------------------------------------------------------------------------------------------|
 | `html_paths`     | Paths where file changes trigger a content refresh. By default: `app/controllers`, `app/helpers`, `app/models`, `app/views`. |
-| `css_paths`      | Paths where file changes trigger a CSS refresh. By default: `app/assets/stylesheets`.                                        |
+| `css_paths`      | Paths where file changes trigger a CSS refresh. By default: `app/assets/stylesheets` or `app/assets/builds` if exists.       |
 | `stimulus_paths` | Paths where file changes trigger a Stimulus controller refresh. By default: `app/javascript/controllers`.                    |
 | `enabled`        | Enable or disable live reloading. By default, it's only enabled in `development`.                                            |
 | `logging`        | Show logs in the browser console when reloading happens. It's false by default.                                              |

--- a/lib/hotwire/spark/engine.rb
+++ b/lib/hotwire/spark/engine.rb
@@ -8,7 +8,7 @@ module Hotwire::Spark
     config.hotwire.spark = ActiveSupport::OrderedOptions.new
     config.hotwire.spark.merge! \
       enabled: Rails.env.development?,
-      css_paths: %w[ app/assets/stylesheets ],
+      css_paths: File.directory?("app/assets/builds") ? %w[ app/assets/builds ] : %w[ app/assets/stylesheets ],
       html_paths: %w[ app/controllers app/helpers app/models app/views ],
       stimulus_paths: %w[ app/javascript/controllers ]
 


### PR DESCRIPTION
This adds `app/assets/builds` for monitoring.

Closes #11