### PR TITLE
fix: ensure paths exist before trying to watch them

### DIFF
--- a/lib/hotwire/spark/engine.rb
+++ b/lib/hotwire/spark/engine.rb
@@ -8,7 +8,7 @@ module Hotwire::Spark
     config.hotwire.spark = ActiveSupport::OrderedOptions.new
     config.hotwire.spark.merge! \
       enabled: Rails.env.development?,
-      css_paths: %w[ app/assets/builds app/assets/stylesheets ],
+      css_paths: File.directory?("app/assets/builds") ? %w[ app/assets/builds ] : %w[ app/assets/stylesheets ],
       html_paths: %w[ app/controllers app/helpers app/models app/views ],
       stimulus_paths: %w[ app/javascript/controllers ]
 

--- a/lib/hotwire/spark/engine.rb
+++ b/lib/hotwire/spark/engine.rb
@@ -8,7 +8,7 @@ module Hotwire::Spark
     config.hotwire.spark = ActiveSupport::OrderedOptions.new
     config.hotwire.spark.merge! \
       enabled: Rails.env.development?,
-      css_paths: File.directory?("app/assets/builds") ? %w[ app/assets/builds ] : %w[ app/assets/stylesheets ],
+      css_paths: %w[ app/assets/builds app/assets/stylesheets ],
       html_paths: %w[ app/controllers app/helpers app/models app/views ],
       stimulus_paths: %w[ app/javascript/controllers ]
 

--- a/lib/hotwire/spark/file_watcher.rb
+++ b/lib/hotwire/spark/file_watcher.rb
@@ -25,7 +25,13 @@ class Hotwire::Spark::FileWatcher
     end
 
     def paths
-      @callbacks_by_path.keys
+      ensure_paths_present @callbacks_by_path.keys
+    end
+
+    def ensure_paths_present(paths)
+      paths.select do |path|
+        path.exist?
+      end
     end
 
     def process_changed_files(changed_files)

--- a/lib/hotwire/spark/file_watcher.rb
+++ b/lib/hotwire/spark/file_watcher.rb
@@ -25,10 +25,10 @@ class Hotwire::Spark::FileWatcher
     end
 
     def paths
-      ensure_paths_present @callbacks_by_path.keys
+      only_existing_paths @callbacks_by_path.keys
     end
 
-    def ensure_paths_present(paths)
+    def only_existing_paths(paths)
       paths.select do |path|
         path.exist?
       end


### PR DESCRIPTION
Some apps might not have the directories that are set by default.
This PR checks if the path exists before trying to watch it.

I ran into this while trying to run it in [an engine](https://github.com/avo-hq/avo). The `dummy` app doesn't have the `app/assets/stylesheets` and `app/javascript/controllers` paths.
This is one example. Others might structure their application differently as well.


> [!NOTE]
> As I am still new to contributing here, I am unfamiliar with some of the design patterns and decisions made thus far in this repo. If I broke any patterns you've established so far, let me know and I'll address that.

