### PR TITLE
Fix #27: Make sure only one listener is running

### DIFF
--- a/lib/hotwire/spark/engine.rb
+++ b/lib/hotwire/spark/engine.rb
@@ -7,7 +7,7 @@ module Hotwire::Spark
     config.hotwire = ActiveSupport::OrderedOptions.new unless config.respond_to?(:hotwire)
     config.hotwire.spark = ActiveSupport::OrderedOptions.new
     config.hotwire.spark.merge! \
-      enabled: Rails.env.development?,
+      enabled: Rails.env.development? && !defined?(Rails::Server).nil?,
       css_paths: File.directory?("app/assets/builds") ? %w[ app/assets/builds ] : %w[ app/assets/stylesheets ],
       html_paths: %w[ app/controllers app/helpers app/models app/views ],
       stimulus_paths: %w[ app/javascript/controllers ]

--- a/test/enabled_test.rb
+++ b/test/enabled_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class EnabledTest < ActiveSupport::TestCase
+  test "that Hotwire-Spark is only enabled when starting the Rails server" do
+    script = <<~RUBY.strip
+      Hotwire::Spark.enabled? ? exit(1) : exit(0)
+    RUBY
+
+    assert system({ "RAILS_ENV" => "development" }, "rails", "runner", script, chdir: Rails.application.root)
+  end
+end


### PR DESCRIPTION
By default, only enable hotwire-spark when starting the Rails server. This prevents starting multiple listeners which can occur if one starts the Rails console or runs a script (`rails runner`).

Technically it's still possible to run multiple listeners if one explicitly enables hotwire-spark. To prevent this, some form of resource shared between multiple processes are required (like a file lock). This seems to be more complicated than it's worth.