### PR TITLE
Move server detection out of the configuration flag

### DIFF
--- a/lib/hotwire-spark.rb
+++ b/lib/hotwire-spark.rb
@@ -21,7 +21,7 @@ module Hotwire::Spark
     end
 
     def enabled?
-      enabled
+      enabled && defined?(Rails::Server)
     end
   end
 end

--- a/lib/hotwire/spark/engine.rb
+++ b/lib/hotwire/spark/engine.rb
@@ -7,7 +7,7 @@ module Hotwire::Spark
     config.hotwire = ActiveSupport::OrderedOptions.new unless config.respond_to?(:hotwire)
     config.hotwire.spark = ActiveSupport::OrderedOptions.new
     config.hotwire.spark.merge! \
-      enabled: Rails.env.development? && defined?(Rails::Server),
+      enabled: Rails.env.development?,
       css_paths: File.directory?("app/assets/builds") ? %w[ app/assets/builds ] : %w[ app/assets/stylesheets ],
       html_paths: %w[ app/controllers app/helpers app/models app/views ],
       stimulus_paths: %w[ app/javascript/controllers ]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,8 @@ end
 
 require "helpers/files_helper"
 
+::ActionCable::Server::Base.prepend(Hotwire::Spark::ActionCable::PersistentCableServer)
+
 class ActiveSupport::TestCase
   include FilesHelper
 


### PR DESCRIPTION
Setting the `enabled` config option to true shouldn't enable hotwire spark in other processes.